### PR TITLE
feat: 更新 Dockerfile 和 Dockerfile.debian，启用 pnpm 作为包管理工具

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,11 +6,14 @@ on:
     paths:
       [
         "Dockerfile",
+        "Dockerfile.debian",
         ".github/workflows/docker-image.yml",
         "**/*.ts",
         "**/*.vue",
+        "**/*.json",
         "package.json",
         "pnpm-lock.yaml",
+        "config/**",
       ]
   workflow_dispatch:
 
@@ -103,3 +106,5 @@ jobs:
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:${{ steps.ver.outputs.version }}
             docker.io/${{ env.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}:latest
           labels: ${{ steps.meta_dh.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,12 @@
 FROM node:20-slim AS builder
 WORKDIR /app
 
-# 安装编译工具（Debian 版本）
+# 启用 pnpm（与项目 lockfile 一致）
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+# 安装编译工具（Debian 版本，better-sqlite3 需要）
 RUN apt-get update && apt-get install -y \
     python3 \
     make \
@@ -13,11 +18,14 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# 复制所有文件
-COPY . .
+# 复制依赖声明
+COPY package.json pnpm-lock.yaml ./
 
-# 安装依赖（使用 npm，避免 pnpm 问题）
-RUN npm install --prefer-offline --no-audit --no-fund
+# 安装依赖（使用 pnpm，与项目 lockfile 一致）
+RUN pnpm install --frozen-lockfile
+
+# 复制其余文件
+COPY . .
 
 # 验证 better-sqlite3 编译结果
 RUN echo "🔍 检查 better-sqlite3 编译文件..." && \
@@ -26,7 +34,7 @@ RUN echo "🔍 检查 better-sqlite3 编译文件..." && \
     (echo "❌ better-sqlite3 编译失败" && exit 1)
 
 # 构建应用
-RUN NITRO_PRESET=node-server npm run build
+RUN NITRO_PRESET=node-server pnpm run build
 
 # 运行阶段：最小化 Debian 镜像
 FROM node:20-slim AS runner

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -4,7 +4,12 @@
 FROM node:20-slim AS builder
 WORKDIR /app
 
-# 安装编译工具（Debian 版本）
+# 启用 pnpm（与项目 lockfile 一致）
+ENV PNPM_HOME="/pnpm"
+ENV PATH="$PNPM_HOME:$PATH"
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+# 安装编译工具（Debian 版本，better-sqlite3 需要）
 RUN apt-get update && apt-get install -y \
     python3 \
     make \
@@ -13,11 +18,14 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# 复制所有文件
-COPY . .
+# 复制依赖声明
+COPY package.json pnpm-lock.yaml ./
 
-# 安装依赖（使用 npm，避免 pnpm 问题）
-RUN npm install --prefer-offline --no-audit --no-fund
+# 安装依赖
+RUN pnpm install --frozen-lockfile
+
+# 复制其余文件
+COPY . .
 
 # 验证 better-sqlite3 编译结果
 RUN echo "🔍 检查 better-sqlite3 编译文件..." && \
@@ -26,7 +34,7 @@ RUN echo "🔍 检查 better-sqlite3 编译文件..." && \
     (echo "❌ better-sqlite3 编译失败" && exit 1)
 
 # 构建应用
-RUN NITRO_PRESET=node-server npm run build
+RUN NITRO_PRESET=node-server pnpm run build
 
 # 运行阶段：最小化 Debian 镜像
 FROM node:20-slim AS runner


### PR DESCRIPTION
变更内容：
- 在 Dockerfile 和 Dockerfile.debian 中启用 pnpm，确保与项目 lockfile 一致。
- 修改依赖安装步骤，使用 pnpm 安装依赖，提升构建效率。
- 复制依赖声明文件后再安装依赖，确保构建过程的准确性。
- 更新构建命令，使用 pnpm 代替 npm。

这些改动优化了 Docker 镜像构建过程，确保依赖管理的一致性和效率。