### PR TITLE
fix: use full tag list in Docker manifest merge step

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -178,10 +178,14 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
+          TAGS=""
+          while IFS= read -r tag; do
+            [ -n "$tag" ] && TAGS="$TAGS -t $tag"
+          done < tags.txt
           docker buildx imagetools create \
-            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $TAGS \
             $(printf 'ghcr.io/${{ github.repository }}@sha256:%s ' *)
 
       - name: Inspect image
         run: |
-          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:${{ steps.meta.outputs.version }}
+          docker buildx imagetools inspect ghcr.io/${{ github.repository }}:latest


### PR DESCRIPTION
The merge job was only using metadata action tags (main, sha-xxx), missing latest, version, and Docker Hub tags. Now reads from tags.txt which includes all tag variants.