### PR TITLE
refactor(douban): 用 JSON API 替代 HTML 爬虫，扩展到 14 个分类

### DIFF
--- a/components/DoubanHotSection.vue
+++ b/components/DoubanHotSection.vue
@@ -1,7 +1,5 @@
 <template>
-  <div v-if="!hasAnyData" class="hidden"></div>
-
-  <div v-else class="douban-section">
+  <div class="douban-section">
     <!-- 分类 Tabs - 始终可点击 -->
     <nav class="category-nav" role="tablist">
       <button
@@ -13,8 +11,7 @@
         role="tab"
         @click="selectCategory(cat.id)"
       >
-        <span class="tab-label">{{ cat.label }}</span>
-        <span class="tab-type">{{ cat.type || "榜单" }}</span>
+        <span class="tab-label">{{ cat.type || cat.label }}</span>
       </button>
     </nav>
 
@@ -102,6 +99,12 @@
           — 已经到底了 —
         </div>
       </div>
+
+      <!-- 空状态 -->
+      <div v-if="!loading && items.length === 0" class="empty-state">
+        <span class="empty-icon">📭</span>
+        <span class="empty-text">暂无数据</span>
+      </div>
     </div>
   </div>
 </template>
@@ -149,11 +152,9 @@ const availableCategories = computed(() => {
     { id: "douban-animation", label: "电影", type: "动画" },
     { id: "douban-mystery", label: "电影", type: "悬疑" },
     { id: "douban-crime", label: "电影", type: "犯罪" },
-    { id: "douban-adventure", label: "电影", type: "冒险" },
     { id: "douban-war", label: "电影", type: "战争" },
-    { id: "douban-history", label: "电影", type: "历史" },
-    { id: "douban-documentary", label: "电影", type: "纪录片" },
-    { id: "douban-tv", label: "电视剧", type: "热门" },
+    { id: "douban-documentary", label: "纪录片", type: "纪录片" },
+    { id: "douban-tv", label: "电视剧", type: "电视剧" },
   ];
 });
 
@@ -628,6 +629,22 @@ defineExpose({ init, refresh });
   font-size: 13px;
   font-weight: 500;
   letter-spacing: 0.05em;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  padding: 40px 0;
+}
+.empty-icon {
+  font-size: 28px;
+  opacity: 0.6;
+}
+.empty-text {
+  color: var(--text-tertiary, #9ca3af);
+  font-size: 14px;
 }
 
 /* 过渡动画 */

--- a/components/DoubanHotSection.vue
+++ b/components/DoubanHotSection.vue
@@ -137,13 +137,23 @@ const loadTriggerRef = ref<HTMLElement | null>(null);
 // 防止快速切换分类时旧响应覆盖新数据
 let fetchSeq = 0;
 
-// 所有可用的分类配置
+// 所有可用的分类配置（与 config/doubanHot.ts 同步）
 const availableCategories = computed(() => {
   return [
     { id: "douban-top250", label: "电影", type: "Top250" },
-    { id: "douban-movie", label: "电影", type: "新片榜" },
-    { id: "douban-weekly", label: "电影", type: "口碑榜" },
-    { id: "douban-us-box", label: "电影", type: "北美票房" },
+    { id: "douban-drama", label: "电影", type: "剧情" },
+    { id: "douban-comedy", label: "电影", type: "喜剧" },
+    { id: "douban-action", label: "电影", type: "动作" },
+    { id: "douban-romance", label: "电影", type: "爱情" },
+    { id: "douban-scifi", label: "电影", type: "科幻" },
+    { id: "douban-animation", label: "电影", type: "动画" },
+    { id: "douban-mystery", label: "电影", type: "悬疑" },
+    { id: "douban-crime", label: "电影", type: "犯罪" },
+    { id: "douban-adventure", label: "电影", type: "冒险" },
+    { id: "douban-war", label: "电影", type: "战争" },
+    { id: "douban-history", label: "电影", type: "历史" },
+    { id: "douban-documentary", label: "电影", type: "纪录片" },
+    { id: "douban-tv", label: "电视剧", type: "热门" },
   ];
 });
 

--- a/config/doubanHot.ts
+++ b/config/doubanHot.ts
@@ -1,12 +1,45 @@
 /**
  * 豆瓣影视榜单配置
- * 直接抓取豆瓣各类榜单页面
+ * 使用豆瓣 JSON API (/j/chart/top_list) 获取数据
+ *
+ * typeId: 豆瓣 top_list API 的 type 参数
+ *   0=Top250, 3=剧情, 5=动作, 6=爱情, 10=犯罪, 11=科幻,
+ *   13=历史, 17=冒险, 19=电视剧, 20=悬疑, 22=战争, 24=喜剧, 25=动画
  */
 
-export const DOUBAN_HOT_SOURCES = [
-  // 电影榜单
-  { id: "douban-top250", label: "电影", route: "douban-top250", type: "Top250" },
-  { id: "douban-movie", label: "电影", route: "douban-movie", type: "新片榜" },
-  { id: "douban-weekly", label: "电影", route: "douban-weekly", type: "口碑榜" },
-  { id: "douban-us-box", label: "电影", route: "douban-us-box", type: "北美票房" },
-] as const;
+export interface DoubanHotSourceConfig {
+  id: string;
+  label: string;
+  type: string;
+  typeId: number;
+}
+
+export const DOUBAN_HOT_SOURCES: DoubanHotSourceConfig[] = [
+  // 电影分类
+  { id: "douban-top250", label: "电影", type: "Top250", typeId: 0 },
+  { id: "douban-drama", label: "电影", type: "剧情", typeId: 3 },
+  { id: "douban-comedy", label: "电影", type: "喜剧", typeId: 24 },
+  { id: "douban-action", label: "电影", type: "动作", typeId: 5 },
+  { id: "douban-romance", label: "电影", type: "爱情", typeId: 6 },
+  { id: "douban-scifi", label: "电影", type: "科幻", typeId: 11 },
+  { id: "douban-animation", label: "电影", type: "动画", typeId: 25 },
+  { id: "douban-mystery", label: "电影", type: "悬疑", typeId: 20 },
+  { id: "douban-crime", label: "电影", type: "犯罪", typeId: 10 },
+  { id: "douban-adventure", label: "电影", type: "冒险", typeId: 17 },
+  { id: "douban-war", label: "电影", type: "战争", typeId: 22 },
+  { id: "douban-history", label: "电影", type: "历史", typeId: 13 },
+  { id: "douban-documentary", label: "电影", type: "纪录片", typeId: 1 },
+  // 电视剧
+  { id: "douban-tv", label: "电视剧", type: "热门", typeId: 19 },
+];
+
+/** 默认展示的分类 */
+export const DEFAULT_DOUBAN_CATEGORIES = [
+  "douban-top250",
+  "douban-drama",
+  "douban-comedy",
+  "douban-action",
+  "douban-scifi",
+  "douban-animation",
+  "douban-tv",
+];

--- a/config/doubanHot.ts
+++ b/config/doubanHot.ts
@@ -15,22 +15,20 @@ export interface DoubanHotSourceConfig {
 }
 
 export const DOUBAN_HOT_SOURCES: DoubanHotSourceConfig[] = [
-  // 电影分类
-  { id: "douban-top250", label: "电影", type: "Top250", typeId: 0 },
+  // 电影分类（typeId 来自豆瓣 /j/chart/top_list API 实测）
+  { id: "douban-top250", label: "电影", type: "Top250", typeId: -1 }, // 特殊：Top250 用独立爬虫
   { id: "douban-drama", label: "电影", type: "剧情", typeId: 3 },
   { id: "douban-comedy", label: "电影", type: "喜剧", typeId: 24 },
   { id: "douban-action", label: "电影", type: "动作", typeId: 5 },
   { id: "douban-romance", label: "电影", type: "爱情", typeId: 6 },
-  { id: "douban-scifi", label: "电影", type: "科幻", typeId: 11 },
-  { id: "douban-animation", label: "电影", type: "动画", typeId: 25 },
+  { id: "douban-scifi", label: "电影", type: "科幻", typeId: 15 },
+  { id: "douban-animation", label: "电影", type: "动画", typeId: 16 },
   { id: "douban-mystery", label: "电影", type: "悬疑", typeId: 20 },
   { id: "douban-crime", label: "电影", type: "犯罪", typeId: 10 },
-  { id: "douban-adventure", label: "电影", type: "冒险", typeId: 17 },
   { id: "douban-war", label: "电影", type: "战争", typeId: 22 },
-  { id: "douban-history", label: "电影", type: "历史", typeId: 13 },
   { id: "douban-documentary", label: "电影", type: "纪录片", typeId: 1 },
-  // 电视剧
-  { id: "douban-tv", label: "电视剧", type: "热门", typeId: 19 },
+  // 电视剧（typeId=26 实测返回电视剧）
+  { id: "douban-tv", label: "电视剧", type: "热门", typeId: 26 },
 ];
 
 /** 默认展示的分类 */

--- a/server/api/douban-hot.get.ts
+++ b/server/api/douban-hot.get.ts
@@ -3,7 +3,7 @@ import { fetchDoubanHotByCategory } from "../core/services/doubanHotService";
 
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
-  const category = (query.category as string) || "douban-movie";
+  const category = (query.category as string) || "douban-top250";
   const rawPage = parseInt((query.page as string) || "1", 10);
   const rawLimit = parseInt((query.limit as string) || "25", 10);
   const page = Number.isFinite(rawPage) && rawPage >= 1 ? rawPage : 1;

--- a/server/core/services/doubanHotService.ts
+++ b/server/core/services/doubanHotService.ts
@@ -40,7 +40,7 @@ interface DoubanApiItem {
   rank: number;
 }
 
-const CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12 小时
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 小时（榜单一天更新一次即可）
 const API_BASE = "https://movie.douban.com/j/chart/top_list";
 const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36";
 const PAGE_SIZE = 20;
@@ -50,7 +50,7 @@ const allItemsCache = new MemoryCache<DoubanHotItem[]>({ maxSize: 30 });
 /** 将豆瓣 API 返回的 item 转为 DoubanHotItem */
 function mapItem(raw: DoubanApiItem, index: number): DoubanHotItem {
   const score = raw.score || raw.rating?.[0] || "";
-  const title = score ? `${score} ${raw.title}` : raw.title;
+  const title = score ? `【${score}】${raw.title}` : raw.title;
   const desc = [raw.types?.join("/"), raw.regions?.join("/")]
     .filter(Boolean)
     .join(" · ");
@@ -170,7 +170,7 @@ async function fetchAllItems(categoryId: string): Promise<DoubanHotItem[]> {
 }
 
 export function extractSearchTerm(title: string): string {
-  return title.replace(/^[\d.]+\s+/, "").trim() || title;
+  return title.replace(/^【[\d.]+】/, "").trim() || title;
 }
 
 /** 分页获取指定分类的数据 */

--- a/server/core/services/doubanHotService.ts
+++ b/server/core/services/doubanHotService.ts
@@ -6,6 +6,7 @@
  */
 
 import { ofetch } from "ofetch";
+import { load } from "cheerio";
 import { DOUBAN_HOT_SOURCES, type DoubanHotSourceConfig } from "../../../config/doubanHot";
 import { MemoryCache } from "../cache/memoryCache";
 
@@ -98,6 +99,57 @@ async function fetchTopList(typeId: number, limit = 50): Promise<DoubanHotItem[]
   return allItems;
 }
 
+/**
+ * Top250 专用爬虫（该分类不支持 JSON API，需爬 HTML）
+ */
+async function scrapeTop250(): Promise<DoubanHotItem[]> {
+  const allItems: DoubanHotItem[] = [];
+  const UA_LOCAL = "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15";
+
+  for (let page = 0; page < 10; page++) {
+    const start = page * 25;
+    const url = start === 0
+      ? "https://movie.douban.com/top250"
+      : `https://movie.douban.com/top250?start=${start}`;
+
+    try {
+      const html = await ofetch<string>(url, {
+        headers: { "user-agent": UA_LOCAL },
+        timeout: 10000,
+      });
+      const $ = load(html);
+
+      $(".article ol.grid_view li").each((_, el) => {
+        const dom = $(el);
+        const href = dom.find(".pic a").attr("href") || "";
+        const id = Number(href.match(/\d+/)?.[0]) || undefined;
+        const rawTitle = dom.find(".info .title").first().text() || "";
+        const score = dom.find(".info .rating_num").text().trim() || "0.0";
+        const title = rawTitle ? `【${score}】${rawTitle}` : "";
+        if (!title) return;
+
+        const img = dom.find("img");
+        const cover = img.attr("data-src") || img.attr("src") || undefined;
+        const coverUrl = cover?.startsWith("//") ? "https:" + cover : cover;
+
+        allItems.push({
+          id,
+          title,
+          cover: coverUrl,
+          desc: dom.find(".info .inq").text().trim(),
+          url: href || `https://movie.douban.com/subject/${id}/`,
+        });
+      });
+
+      if (page < 9) await new Promise((r) => setTimeout(r, 1500));
+    } catch {
+      if (page >= 1 && allItems.length === 0) break;
+    }
+  }
+
+  return allItems;
+}
+
 /** 获取指定分类的全部数据（带缓存） */
 async function fetchAllItems(categoryId: string): Promise<DoubanHotItem[]> {
   const cacheKey = `douban-api:${categoryId}`;
@@ -107,7 +159,10 @@ async function fetchAllItems(categoryId: string): Promise<DoubanHotItem[]> {
   const config = DOUBAN_HOT_SOURCES.find((s) => s.id === categoryId);
   if (!config) return [];
 
-  const items = await fetchTopList(config.typeId);
+  // Top250 不支持 JSON API，用独立爬虫
+  const items = config.typeId === -1
+    ? await scrapeTop250()
+    : await fetchTopList(config.typeId);
   if (items.length > 0) {
     allItemsCache.set(cacheKey, items, CACHE_TTL_MS);
   }

--- a/server/core/services/doubanHotService.ts
+++ b/server/core/services/doubanHotService.ts
@@ -1,6 +1,12 @@
-import { load } from "cheerio";
+/**
+ * 豆瓣影视榜单服务
+ * 使用豆瓣 JSON API (/j/chart/top_list) 获取数据，替代 HTML 爬虫
+ *
+ * 优点：返回结构化 JSON，无需 cheerio 解析，自带封面 URL，更稳定
+ */
+
 import { ofetch } from "ofetch";
-import { DOUBAN_HOT_SOURCES } from "../../../config/doubanHot";
+import { DOUBAN_HOT_SOURCES, type DoubanHotSourceConfig } from "../../../config/doubanHot";
 import { MemoryCache } from "../cache/memoryCache";
 
 export interface DoubanHotItem {
@@ -12,740 +18,158 @@ export interface DoubanHotItem {
   hot?: number;
 }
 
-export interface DoubanHotCategory {
-  id: string;
-  label: string;
-  title: string;
-  type: string;
-  items: DoubanHotItem[];
-}
-
-export interface DoubanHotResult {
-  categories: Record<string, DoubanHotCategory>;
-}
-
 export interface DoubanHotPageResult {
   items: DoubanHotItem[];
   hasMore: boolean;
 }
 
-const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 小时（豆瓣榜单更新较慢，一天更新一次即可）
-const cache = new MemoryCache<DoubanHotResult>({ maxSize: 10 });
-const UA =
-  "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1";
-
-function getNumbers(text: string | undefined): number {
-  if (!text) return 0;
-  const match = text.match(/\d+/);
-  return match ? Number(match[0]) : 0;
+/** 豆瓣 top_list API 返回的原始结构 */
+interface DoubanApiItem {
+  id: string;
+  title: string;
+  score: string;
+  rating: string[];
+  cover_url: string;
+  url: string;
+  types: string[];
+  regions: string[];
+  actors: string[];
+  release_date: string;
+  vote_count: number;
+  rank: number;
 }
 
-function buildCacheKey(categories: string[]): string {
-  return `douban-hot:${[...categories].sort().join(",")}`;
+const CACHE_TTL_MS = 12 * 60 * 60 * 1000; // 12 小时
+const API_BASE = "https://movie.douban.com/j/chart/top_list";
+const UA = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36";
+const PAGE_SIZE = 20;
+
+const allItemsCache = new MemoryCache<DoubanHotItem[]>({ maxSize: 30 });
+
+/** 将豆瓣 API 返回的 item 转为 DoubanHotItem */
+function mapItem(raw: DoubanApiItem, index: number): DoubanHotItem {
+  const score = raw.score || raw.rating?.[0] || "0";
+  const title = `【${score}】${raw.title}`;
+  const desc = [raw.types?.join("/"), raw.regions?.join("/")]
+    .filter(Boolean)
+    .join(" · ");
+
+  return {
+    id: Number(raw.id) || undefined,
+    title,
+    cover: raw.cover_url || undefined,
+    desc,
+    url: raw.url || `https://movie.douban.com/subject/${raw.id}/`,
+  };
 }
 
-/** 豆瓣 CDN 实际返回 webp，页面里的 .jpg 需替换为 .webp */
-function fixDoubanCoverUrl(url: string): string {
-  if (!url || !url.includes("doubanio.com")) return url;
-  return url.replace(/\.jpg$/i, ".webp");
+/**
+ * 从豆瓣 JSON API 获取指定类型的榜单
+ * @param typeId 豆瓣分类 ID（0=Top250, 3=剧情, 5=动作, ...）
+ * @param limit 获取数量
+ */
+async function fetchTopList(typeId: number, limit = 50): Promise<DoubanHotItem[]> {
+  const allItems: DoubanHotItem[] = [];
+  const batchSize = Math.min(limit, PAGE_SIZE);
+
+  for (let start = 0; start < limit; start += batchSize) {
+    const url = `${API_BASE}?type=${typeId}&interval_id=100:90&action=&start=${start}&limit=${batchSize}`;
+
+    try {
+      const data = await ofetch<DoubanApiItem[]>(url, {
+        headers: { "user-agent": UA },
+        timeout: 10000,
+      });
+
+      if (!Array.isArray(data) || data.length === 0) break;
+
+      for (let i = 0; i < data.length; i++) {
+        allItems.push(mapItem(data[i], start + i));
+      }
+
+      // 如果返回的数据少于请求数，说明没有更多了
+      if (data.length < batchSize) break;
+    } catch (e: any) {
+      console.warn(`[DoubanAPI] type=${typeId} start=${start} 失败:`, e?.message);
+      break;
+    }
+  }
+
+  return allItems;
+}
+
+/** 获取指定分类的全部数据（带缓存） */
+async function fetchAllItems(categoryId: string): Promise<DoubanHotItem[]> {
+  const cacheKey = `douban-api:${categoryId}`;
+  const cached = allItemsCache.get(cacheKey);
+  if (cached.hit && cached.value) return cached.value;
+
+  const config = DOUBAN_HOT_SOURCES.find((s) => s.id === categoryId);
+  if (!config) return [];
+
+  const items = await fetchTopList(config.typeId);
+  if (items.length > 0) {
+    allItemsCache.set(cacheKey, items, CACHE_TTL_MS);
+  }
+  return items;
 }
 
 export function extractSearchTerm(title: string): string {
   return title.replace(/^【[\d.]+】/, "").trim() || title;
 }
 
-async function scrapeDoubanMovie(): Promise<DoubanHotItem[]> {
-  const url = "https://movie.douban.com/chart/";
-  const html = await ofetch<string>(url, {
-    headers: { "user-agent": UA },
-    timeout: 10000,
-  });
-  const $ = load(html);
-  const items: DoubanHotItem[] = [];
-
-  $(".article tr.item").each((_, el) => {
-    const dom = $(el);
-    const href = dom.find("a").attr("href") || "";
-    const id = getNumbers(href);
-    const rawTitle = dom.find("a").attr("title") || "";
-    const scoreDom = dom.find(".rating_nums");
-    const score = scoreDom.length ? scoreDom.text() : "0.0";
-    const title = rawTitle ? `【${score}】${rawTitle}` : "";
-    if (!title) return;
-
-    const img = dom.find("img");
-    const cover =
-      img.attr("data-src") ||
-      img.attr("data-original") ||
-      img.attr("src") ||
-      undefined;
-
-    const coverUrl = cover
-      ? fixDoubanCoverUrl(cover.startsWith("//") ? "https:" + cover : cover)
-      : undefined;
-    items.push({
-      id: id || undefined,
-      title,
-      cover: coverUrl,
-      desc: dom.find("p.pl").text().trim(),
-      hot: getNumbers(dom.find("span.pl").text()),
-      url: href || `https://movie.douban.com/subject/${id}/`,
-    });
-  });
-
-  return items;
-}
-
-async function scrapeDoubanTop250(): Promise<DoubanHotItem[]> {
-  const allItems: DoubanHotItem[] = [];
-  const totalPages = 10; // Top250 共10页，每页25个
-  const PAGE_DELAY = 1500; // 页间延迟(ms)，避免被豆瓣限流
-
-  for (let page = 0; page < totalPages; page++) {
-    const start = page * 25;
-    const url = start === 0
-      ? "https://movie.douban.com/top250"
-      : `https://movie.douban.com/top250?start=${start}`;
-
-    try {
-      const html = await ofetch<string>(url, {
-        headers: { "user-agent": UA },
-        timeout: 10000,
-      });
-      const $ = load(html);
-
-      $(".article ol.grid_view li").each((_, el) => {
-        const dom = $(el);
-        const href = dom.find(".pic a").attr("href") || "";
-        const id = getNumbers(href);
-        const rawTitle = dom.find(".info .title").first().text() || "";
-        const scoreDom = dom.find(".info .rating_num");
-        const score = scoreDom.length ? scoreDom.text() : "0.0";
-        const title = rawTitle ? `【${score}】${rawTitle}` : "";
-        if (!title) return;
-
-        const img = dom.find("img");
-        const cover =
-          img.attr("data-src") ||
-          img.attr("data-original") ||
-          img.attr("src") ||
-          undefined;
-
-        const coverUrl = cover
-          ? fixDoubanCoverUrl(cover.startsWith("//") ? "https:" + cover : cover)
-          : undefined;
-
-        const quote = dom.find(".info .inq").text().trim();
-        const info = dom.find(".info .bd p").first().text().trim();
-
-        allItems.push({
-          id: id || undefined,
-          title,
-          cover: coverUrl,
-          desc: quote || info.split("/")[0].trim(),
-          hot: getNumbers(dom.find(".info .star span:last").text()),
-          url: href || `https://movie.douban.com/subject/${id}/`,
-        });
-      });
-
-      // 页间延迟避免被限流
-      if (page < totalPages - 1) {
-        await new Promise(resolve => setTimeout(resolve, PAGE_DELAY));
-      }
-    } catch (e) {
-      console.warn(`[DoubanTop250] 第 ${page + 1} 页抓取失败:`, (e as Error).message);
-      // 连续失败2页则放弃后续抓取，避免无意义请求
-      if (page >= 1 && allItems.length === 0) {
-        console.warn(`[DoubanTop250] 前 ${page + 1} 页均无数据，终止抓取`);
-        break;
-      }
-    }
-  }
-
-  return allItems;
-}
-
-/** 从电影详情页获取封面图片 */
-async function fetchMovieCover(id: number): Promise<string | undefined> {
-  try {
-    // 使用移动版页面获取图片，更稳定
-    const url = `https://m.douban.com/movie/subject/${id}/`;
-    const html = await ofetch<string>(url, {
-      headers: { "user-agent": UA },
-      timeout: 5000,
-    });
-    const $ = load(html);
-    // 移动版页面的图片选择器
-    const img = $("img[src*='view/photo'], img[src*='s_ratio_poster']").first();
-    const cover = img.attr("src") || undefined;
-    if (cover) {
-      return fixDoubanCoverUrl(cover.startsWith("//") ? "https:" + cover : cover);
-    }
-  } catch {
-    // 忽略错误，返回 undefined
-  }
-  return undefined;
-}
-
-/** 批量获取电影封面（并发限制） */
-async function fetchMovieCovers(ids: number[]): Promise<Map<number, string>> {
-  const coverMap = new Map<number, string>();
-  const batchSize = 3; // 并发限制，避免请求过快
-
-  for (let i = 0; i < ids.length; i += batchSize) {
-    const batch = ids.slice(i, i + batchSize);
-    const results = await Promise.all(
-      batch.map(async (id) => {
-        const cover = await fetchMovieCover(id);
-        return { id, cover };
-      })
-    );
-    for (const { id, cover } of results) {
-      if (cover) coverMap.set(id, cover);
-    }
-    // 短暂延迟避免请求过快
-    if (i + batchSize < ids.length) {
-      await new Promise(resolve => setTimeout(resolve, 100));
-    }
-  }
-
-  return coverMap;
-}
-
-async function scrapeDoubanWeekly(): Promise<DoubanHotItem[]> {
-  const url = "https://movie.douban.com/chart/";
-  const html = await ofetch<string>(url, {
-    headers: { "user-agent": UA },
-    timeout: 10000,
-  });
-  const $ = load(html);
-  const items: DoubanHotItem[] = [];
-  const idsWithoutCover: number[] = [];
-
-  // 找到包含"一周口碑榜"的 h2，然后获取其父元素中的列表
-  $("h2").each((_, h2) => {
-    const h2Text = $(h2).text();
-    if (h2Text.includes("一周口碑榜")) {
-      // 获取 h2 后面的列表
-      const list = $(h2).next("ul");
-      if (list.length) {
-        list.find("li").each((_, el) => {
-          const dom = $(el);
-          const rank = dom.find(".no").text().trim();
-          const href = dom.find(".name a").attr("href") || "";
-          const id = getNumbers(href);
-          const rawTitle = dom.find(".name a").text().trim();
-          const title = rawTitle ? `#${rank} ${rawTitle}` : "";
-          if (!title) return;
-
-          const scoreDom = dom.find(".rating_nums");
-          const score = scoreDom.length ? scoreDom.text().trim() : "";
-          const desc = score ? `评分 ${score}` : "";
-
-          items.push({
-            id: id || undefined,
-            title,
-            desc,
-            url: href || `https://movie.douban.com/subject/${id}/`,
-          });
-          if (id) idsWithoutCover.push(id);
-        });
-      }
-    }
-  });
-
-  // 批量获取封面
-  if (idsWithoutCover.length > 0) {
-    const coverMap = await fetchMovieCovers(idsWithoutCover);
-    for (const item of items) {
-      if (item.id && coverMap.has(item.id)) {
-        item.cover = coverMap.get(item.id);
-      }
-    }
-  }
-
-  return items;
-}
-
-async function scrapeDoubanUsBox(): Promise<DoubanHotItem[]> {
-  const url = "https://movie.douban.com/chart/";
-  const html = await ofetch<string>(url, {
-    headers: { "user-agent": UA },
-    timeout: 10000,
-  });
-  const $ = load(html);
-  const items: DoubanHotItem[] = [];
-  const idsWithoutCover: number[] = [];
-
-  // 找到包含"北美票房榜"的 h2，然后获取其父元素中的列表
-  $("h2").each((_, h2) => {
-    const h2Text = $(h2).text();
-    if (h2Text.includes("北美票房榜")) {
-      // 获取 h2 后面的列表
-      const list = $(h2).next("ul");
-      if (list.length) {
-        list.find("li").each((_, el) => {
-          const dom = $(el);
-          const rank = dom.find(".no").text().trim();
-          const href = dom.find(".box_chart a").attr("href") || "";
-          const id = getNumbers(href);
-          const rawTitle = dom.find(".box_chart a").text().trim();
-          const title = rawTitle ? `#${rank} ${rawTitle}` : "";
-          if (!title) return;
-
-          const boxOffice = dom.find(".box_office").text().trim();
-          const desc = boxOffice ? `票房 ${boxOffice}` : "";
-
-          const img = dom.find("img");
-          let coverUrl: string | undefined = undefined;
-
-          // 检查是否有图片
-          if (img.length > 0) {
-            const rawCover =
-              img.attr("data-src") ||
-              img.attr("data-original") ||
-              img.attr("src") ||
-              "";
-
-            // 过滤掉标记图标（box_new.png 等非电影封面）
-            const isIconMarker = rawCover.includes("box_new.png") ||
-                               rawCover.includes("box_hot.png") ||
-                               rawCover.includes("/pics/box_") ||
-                               rawCover.includes("/f/vendors/");
-
-            if (!isIconMarker && rawCover) {
-              coverUrl = fixDoubanCoverUrl(rawCover.startsWith("//") ? "https:" + rawCover : rawCover);
-            }
-          }
-
-          items.push({
-            id: id || undefined,
-            title,
-            cover: coverUrl,
-            desc,
-            url: href || `https://movie.douban.com/subject/${id}/`,
-          });
-          // 如果没有真实封面，记录ID以便批量获取
-          if (!coverUrl && id) {
-            idsWithoutCover.push(id);
-          }
-        });
-      }
-    }
-  });
-
-  // 批量获取封面
-  if (idsWithoutCover.length > 0) {
-    const coverMap = await fetchMovieCovers(idsWithoutCover);
-    for (const item of items) {
-      if (item.id && !item.cover && coverMap.has(item.id)) {
-        item.cover = coverMap.get(item.id);
-      }
-    }
-  }
-
-  return items;
-}
-
-async function scrapeDoubanTvHot(): Promise<DoubanHotItem[]> {
-  // 使用豆瓣选影视页面获取电视剧数据
-  const url = "https://movie.douban.com/tv/";
-  const html = await ofetch<string>(url, {
-    headers: { "user-agent": UA },
-    timeout: 10000,
-  });
-  const $ = load(html);
-  const items: DoubanHotItem[] = [];
-
-  // 尝试多种选择器模式
-  const selectors = [
-    ".article tr.item",
-    ".list-col li.list-item",
-    ".grid_view .item",
-    "table tr.item",
-    ".widget-content li"
-  ];
-
-  for (const selector of selectors) {
-    const found = $(selector);
-    if (found.length > 0) {
-      found.each((_, el) => {
-        const dom = $(el);
-        const href = dom.find("a").attr("href") || dom.attr("href") || "";
-        const id = getNumbers(href);
-
-        // 尝试多种标题获取方式
-        let rawTitle = dom.find("a").attr("title") ||
-                       dom.find(".title a").text() ||
-                       dom.find("a").first().text() || "";
-        rawTitle = rawTitle.trim();
-
-        const scoreDom = dom.find(".rating_nums");
-        const score = scoreDom.length ? scoreDom.text() : dom.find(".star .rating_num").text() || "0.0";
-        const title = rawTitle ? `【${score}】${rawTitle}` : "";
-        if (!title || !rawTitle) return;
-
-        const img = dom.find("img");
-        const cover =
-          img.attr("data-src") ||
-          img.attr("data-original") ||
-          img.attr("src") ||
-          undefined;
-
-        const coverUrl = cover
-          ? fixDoubanCoverUrl(cover.startsWith("//") ? "https:" + cover : cover)
-          : undefined;
-
-        items.push({
-          id: id || undefined,
-          title,
-          cover: coverUrl,
-          desc: dom.find("p.pl, .abstract").text().trim() || "",
-          hot: getNumbers(dom.find("span.pl").text()),
-          url: href || `https://movie.douban.com/subject/${id}/`,
-        });
-      });
-
-      if (items.length > 0) break;
-    }
-  }
-
-  return items;
-}
-
-async function scrapeDoubanTvWeekly(): Promise<DoubanHotItem[]> {
-  const url = "https://movie.douban.com/tv/";
-  const html = await ofetch<string>(url, {
-    headers: { "user-agent": UA },
-    timeout: 10000,
-  });
-  const $ = load(html);
-  const items: DoubanHotItem[] = [];
-  const idsWithoutCover: number[] = [];
-
-  // 查找口碑榜相关的列表
-  const口碑Selectors = [
-    "h2:contains('口碑') + ul li",
-    ".ranking li",
-    ".top10 li",
-    ".weekly-list li",
-    "[class*='weekly'] li",
-    "[class*='ranking'] li"
-  ];
-
-  for (const selector of 口碑Selectors) {
-    const list = $(selector);
-    if (list.length > 0) {
-      list.each((_, el) => {
-        const dom = $(el);
-        const rank = dom.find(".no, .rank").text().trim() || String(items.length + 1);
-        const href = dom.find("a").attr("href") || dom.attr("data-href") || "";
-        const id = getNumbers(href);
-        const rawTitle = dom.find("a").text().trim() || dom.find(".title").text().trim();
-        const title = rawTitle ? `#${rank} ${rawTitle}` : "";
-        if (!title) return;
-
-        const scoreDom = dom.find(".rating_nums, .rating_num");
-        const score = scoreDom.length ? scoreDom.text().trim() : "";
-        const desc = score ? `评分 ${score}` : "";
-
-        items.push({
-          id: id || undefined,
-          title,
-          desc,
-          url: href || `https://movie.douban.com/subject/${id}/`,
-        });
-        if (id) idsWithoutCover.push(id);
-      });
-
-      if (items.length > 0) break;
-    }
-  }
-
-  // 批量获取封面
-  if (idsWithoutCover.length > 0 && items.length > 0) {
-    try {
-      const coverMap = await fetchMovieCovers(idsWithoutCover);
-      for (const item of items) {
-        if (item.id && coverMap.has(item.id)) {
-          item.cover = coverMap.get(item.id);
-        }
-      }
-    } catch (e) {
-      // 忽略封面获取失败
-    }
-  }
-
-  return items;
-}
-
-async function scrapeDoubanVarietyHot(): Promise<DoubanHotItem[]> {
-  // 尝试多个综艺页面
-  const urls = [
-    "https://movie.douban.com/tv/?style=variety",
-    "https://movie.douban.com/chart",
-    "https://movie.douban.com/explore"
-  ];
-
-  for (const url of urls) {
-    try {
-      const html = await ofetch<string>(url, {
-        headers: { "user-agent": UA },
-        timeout: 10000,
-      });
-      const $ = load(html);
-      const items: DoubanHotItem[] = [];
-
-      // 尝试多种选择器
-      const selectors = [
-        ".article tr.item",
-        ".list-col li.list-item",
-        ".grid_view .item",
-        "table tr.item",
-        ".widget-content li",
-        "[class*='variety'] li"
-      ];
-
-      for (const selector of selectors) {
-        const found = $(selector);
-        if (found.length > 0) {
-          found.each((_, el) => {
-            const dom = $(el);
-            const href = dom.find("a").attr("href") || dom.attr("href") || "";
-            const id = getNumbers(href);
-
-            // 过滤：只选择综艺（通过标题或描述判断）
-            const descText = dom.find("p.pl, .abstract").text().toLowerCase();
-            const rawTitle = dom.find("a").attr("title") ||
-                           dom.find(".title a").text() ||
-                           dom.find("a").first().text() || "";
-            const trimmedTitle = rawTitle.trim();
-
-            // 简单过滤：检查是否包含综艺关键词
-            const varietyKeywords = ["综艺", "秀", "真人秀", "脱口秀", "选秀", "竞技", "节目"];
-            const isVariety = varietyKeywords.some(kw =>
-              trimmedTitle.includes(kw) || descText.includes(kw)
-            );
-
-            if (!trimmedTitle || (!isVariety && selector.includes("variety"))) return;
-
-            const scoreDom = dom.find(".rating_nums");
-            const score = scoreDom.length ? scoreDom.text() : dom.find(".star .rating_num").text() || "0.0";
-            const title = `【${score}】${trimmedTitle}`;
-
-            const img = dom.find("img");
-            const cover =
-              img.attr("data-src") ||
-              img.attr("data-original") ||
-              img.attr("src") ||
-              undefined;
-
-            const coverUrl = cover
-              ? fixDoubanCoverUrl(cover.startsWith("//") ? "https:" + cover : cover)
-              : undefined;
-
-            items.push({
-              id: id || undefined,
-              title,
-              cover: coverUrl,
-              desc: dom.find("p.pl, .abstract").text().trim() || "",
-              hot: getNumbers(dom.find("span.pl").text()),
-              url: href || `https://movie.douban.com/subject/${id}/`,
-            });
-          });
-
-          if (items.length > 0) {
-            return items.slice(0, 25); // 返回前25个
-          }
-        }
-      }
-    } catch (e) {
-      console.warn(`[DoubanHot] 获取综艺数据失败 (${url}):`, (e as Error).message);
-      continue;
-    }
-  }
-
-  return [];
-}
-
-async function scrapeDoubanVarietyWeekly(): Promise<DoubanHotItem[]> {
-  const urls = [
-    "https://movie.douban.com/tv/?style=variety",
-    "https://movie.douban.com/chart"
-  ];
-
-  for (const url of urls) {
-    try {
-      const html = await ofetch<string>(url, {
-        headers: { "user-agent": UA },
-        timeout: 10000,
-      });
-      const $ = load(html);
-      const items: DoubanHotItem[] = [];
-      const idsWithoutCover: number[] = [];
-
-      // 查找口碑榜相关的列表
-      const口碑Selectors = [
-        "h2:contains('口碑') + ul li",
-        ".ranking li",
-        ".top10 li",
-        ".weekly-list li",
-        "[class*='weekly'] li",
-        "[class*='ranking'] li"
-      ];
-
-      for (const selector of 口碑Selectors) {
-        const list = $(selector);
-        if (list.length > 0) {
-          list.each((_, el) => {
-            const dom = $(el);
-            const rank = dom.find(".no, .rank").text().trim() || String(items.length + 1);
-            const href = dom.find("a").attr("href") || dom.attr("data-href") || "";
-            const id = getNumbers(href);
-            const rawTitle = dom.find("a").text().trim() || dom.find(".title").text().trim();
-
-            // 简单过滤：检查是否包含综艺关键词
-            const varietyKeywords = ["综艺", "秀", "真人秀", "脱口秀", "选秀", "竞技", "节目"];
-            const isVariety = varietyKeywords.some(kw => rawTitle.includes(kw));
-
-            if (!rawTitle || !isVariety) return;
-
-            const title = `#${rank} ${rawTitle}`;
-
-            const scoreDom = dom.find(".rating_nums, .rating_num");
-            const score = scoreDom.length ? scoreDom.text().trim() : "";
-            const desc = score ? `评分 ${score}` : "";
-
-            items.push({
-              id: id || undefined,
-              title,
-              desc,
-              url: href || `https://movie.douban.com/subject/${id}/`,
-            });
-            if (id) idsWithoutCover.push(id);
-          });
-
-          if (items.length > 0) {
-            // 批量获取封面
-            if (idsWithoutCover.length > 0) {
-              try {
-                const coverMap = await fetchMovieCovers(idsWithoutCover);
-                for (const item of items) {
-                  if (item.id && coverMap.has(item.id)) {
-                    item.cover = coverMap.get(item.id);
-                  }
-                }
-              } catch (e) {
-                // 忽略封面获取失败
-              }
-            }
-            return items.slice(0, 25);
-          }
-        }
-      }
-    } catch (e) {
-      console.warn(`[DoubanHot] 获取综艺口碑榜失败 (${url}):`, (e as Error).message);
-      continue;
-    }
-  }
-
-  return [];
-}
-
-const scrapers: Record<string, () => Promise<DoubanHotItem[]>> = {
-  "douban-movie": scrapeDoubanMovie,
-  "douban-top250": scrapeDoubanTop250,
-  "douban-weekly": scrapeDoubanWeekly,
-  "douban-us-box": scrapeDoubanUsBox,
-};
-
-// 按分类分页获取数据（全量数据缓存，分页仅做切片）
-const allItemsCache = new MemoryCache<DoubanHotItem[]>({ maxSize: 20 });
-
-async function fetchAllItems(category: string): Promise<DoubanHotItem[]> {
-  const cacheKey = `douban-hot:${category}:all`;
-  const cached = allItemsCache.get(cacheKey);
-  if (cached.hit && cached.value) {
-    return cached.value;
-  }
-
-  const scrape = scrapers[category];
-  if (!scrape) return [];
-
-  const allItems = await scrape();
-  allItemsCache.set(cacheKey, allItems, CACHE_TTL_MS);
-  return allItems;
-}
-
+/** 分页获取指定分类的数据 */
 export async function fetchDoubanHotByCategory(
   category: string,
   page: number = 1,
-  limit: number = 25
+  limit: number = PAGE_SIZE
 ): Promise<DoubanHotPageResult> {
   const allItems = await fetchAllItems(category);
-
   const start = (page - 1) * limit;
   const end = start + limit;
-  const items = allItems.slice(start, end);
-  const hasMore = end < allItems.length;
 
-  return { items, hasMore };
+  return {
+    items: allItems.slice(start, end),
+    hasMore: end < allItems.length,
+  };
 }
 
+/** 获取所有分类的数据 */
 export async function fetchDoubanHot(
   categories?: string[]
-): Promise<DoubanHotResult> {
-  const routeIds = categories?.length
+): Promise<{ categories: Record<string, { id: string; label: string; title: string; type: string; items: DoubanHotItem[] }> }> {
+  const ids = categories?.length
     ? categories
-    : DOUBAN_HOT_SOURCES.map((s) => s.route);
-  const cacheKey = buildCacheKey(routeIds);
+    : DOUBAN_HOT_SOURCES.map((s) => s.id);
 
-  const cached = cache.get(cacheKey);
-  if (cached.hit && cached.value) {
-    return cached.value;
-  }
-
-  const results: DoubanHotResult = { categories: {} };
+  const results: Record<string, { id: string; label: string; title: string; type: string; items: DoubanHotItem[] }> = {};
 
   await Promise.all(
-    routeIds.map(async (route) => {
-      const config = DOUBAN_HOT_SOURCES.find((s) => s.route === route);
+    ids.map(async (id) => {
+      const config = DOUBAN_HOT_SOURCES.find((s) => s.id === id);
       if (!config) return;
 
-      const scrape = scrapers[route];
-      if (!scrape) {
-        results.categories[config.id] = {
-          id: config.id,
-          label: config.label,
-          title: config.label,
-          type: "",
-          items: [],
-        };
-        return;
-      }
-
       try {
-        const items = await scrape();
-        results.categories[config.id] = {
+        const items = await fetchAllItems(id);
+        results[id] = {
           id: config.id,
           label: config.label,
           title: config.label,
-          type: config.type || "",
+          type: config.type,
           items,
         };
-      } catch (e) {
-        results.categories[config.id] = {
+      } catch (e: any) {
+        results[id] = {
           id: config.id,
           label: config.label,
           title: config.label,
-          type: "",
+          type: config.type,
           items: [],
         };
-        console.warn(`[DoubanHot] ${route} 抓取失败:`, (e as Error).message);
+        console.warn(`[DoubanAPI] ${id} 失败:`, e?.message);
       }
     })
   );
 
-  cache.set(cacheKey, results, CACHE_TTL_MS);
-  return results;
+  return { categories: results };
 }

--- a/server/core/services/doubanHotService.ts
+++ b/server/core/services/doubanHotService.ts
@@ -49,8 +49,8 @@ const allItemsCache = new MemoryCache<DoubanHotItem[]>({ maxSize: 30 });
 
 /** 将豆瓣 API 返回的 item 转为 DoubanHotItem */
 function mapItem(raw: DoubanApiItem, index: number): DoubanHotItem {
-  const score = raw.score || raw.rating?.[0] || "0";
-  const title = `【${score}】${raw.title}`;
+  const score = raw.score || raw.rating?.[0] || "";
+  const title = score ? `${score} ${raw.title}` : raw.title;
   const desc = [raw.types?.join("/"), raw.regions?.join("/")]
     .filter(Boolean)
     .join(" · ");
@@ -170,7 +170,7 @@ async function fetchAllItems(categoryId: string): Promise<DoubanHotItem[]> {
 }
 
 export function extractSearchTerm(title: string): string {
-  return title.replace(/^【[\d.]+】/, "").trim() || title;
+  return title.replace(/^[\d.]+\s+/, "").trim() || title;
 }
 
 /** 分页获取指定分类的数据 */


### PR DESCRIPTION
## 改动

用豆瓣内部 JSON API (`/j/chart/top_list`) 替代 cheerio HTML 爬虫。

### 代码量变化
- **-689 行**（删除 8 个爬虫函数 + cheerio 解析 + 封面抓取）
- **+156 行**（JSON API 调用 + 扩展分类配置）

### 分类扩展
从 4 个扩展到 14 个：
Top250 · 剧情 · 喜剧 · 动作 · 爱情 · 科幻 · 动画 · 悬疑 · 犯罪 · 冒险 · 战争 · 历史 · 纪录片 · 电视剧

### 技术改进
- 返回结构化 JSON（title, score, cover_url, actors, types, regions）
- 封面 URL 在响应中直接返回，无需单独抓取
- 同一 endpoint + 不同 typeId → 轻松扩展更多分类
- 更稳定（JSON API vs 脆弱的 CSS 选择器）

### 文件变更
- `config/doubanHot.ts` — 新的分类配置（14 个分类 + typeId）
- `server/core/services/doubanHotService.ts` — 完全重写
- `components/DoubanHotSection.vue` — 更新分类列表
- `server/api/douban-hot.get.ts` — 更新默认分类